### PR TITLE
Update to fix reboot bug

### DIFF
--- a/espsense-bn-link-example.yaml
+++ b/espsense-bn-link-example.yaml
@@ -1,7 +1,17 @@
 esphome:
 #based on yaml from esphome titled RGB Smart Plug 16A with power monitoring
 #All the GPIO's have been updated to match the bn-link and espSense code added
-  name: bnlink1
+#GPIOS for BN-Link BNC-60/U133TJ
+#GPIO01	Led1i
+#GPIO03	Button1
+#GPIO04	BL0937 CF
+#GPIO05	HLWBL CF1
+#GPIO12	HLWBL SELi
+#GPIO13	Led2i
+#GPIO14	Relay1
+#
+
+name: bnlink1
   platform: ESP8266
   board: esp01_1m
   includes:
@@ -81,7 +91,7 @@ sensor:
       unit_of_measurement: W
       id: wattage
       filters:
-        - delta: 0.1 # Don't report if change is less than 10W from previous reported, make it smaller if you got smaller load
+        - delta: 5 # Don't report if change is less than 5W from previous reported, make it smaller if you got smaller load
         - multiply: .14
             
     current:
@@ -104,14 +114,6 @@ sensor:
             - 356.0 -> 119.7 #load was on
     change_mode_every: 1 #Skips first reading after each change, so this will double the update interval. Default 8
     update_interval: 10s #10s setting => 20 second effective update rate for Power, 40 second for Current and Voltage. Default 60s
-
-# Reports the total Power so-far each day, resets at midnight, see https://esphome.io/components/sensor/total_daily_energy.html
-  - platform: total_daily_energy
-    name: ${friendly_name} Total Daily Energy
-    power_id: wattage
-    filters:
-        - multiply: 0.001  ## convert Wh to kWh
-    unit_of_measurement: kWh
 
 binary_sensor:
 # Reports if this device is Connected or not

--- a/espsense-bn-link-example.yaml
+++ b/espsense-bn-link-example.yaml
@@ -23,6 +23,10 @@ name: bnlink1
 wifi:
   ssid: "ssid"
   password: "password"
+  reboot_timeout: 0s 
+  #this reboot_timeout may not be necessary--I'm pretty sure it's the API reboot_timeout that's needed. 
+  #If you have wifi issues you should remove this so the device will automatically reset after a lost wifi connection.
+  #More testing is needed here.
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
@@ -36,6 +40,11 @@ logger:
 
 # Enable Home Assistant API
 api:
+  reboot_timeout: 0s
+  #There appears to be some sort of bug where the api connection gets lost after about 15 minutes due to a bad pointer or something in the espHome code.(Lots of issues related to this are posted)
+  #Due to this API disconnect error the unit will reboot 15 minutes after that and cause the relay to briefly blink off then back on.
+  #The API is not actually down as you can create a new connection to it easily.
+  #If you're using this for Sense, then the api isn't even needed anyway.   Setting reboot_timeout to 0s disables this restart function.
 
 ota:
 


### PR DESCRIPTION
Added line to prevent watchdog timeout in event of an API connection error (seems to happen automatically after about 15 mins for some reason)