### PR TITLE
Convert ESPSense to an external component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **/platformio.ini
 /secrets.yaml
 *.pcap*
+*.pyc

--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ From the included example YAML file:
 ```yaml
 external_components:
   # Pull the esphome component in from this GitHub repo
-  # - source: github://cbpowell/ESPSense
-  - source:
-      type: local
-      path: components 
+  - source: github://cbpowell/ESPSense
     components: [ espsense ]
 
 # Template sensor as an example

--- a/README.md
+++ b/README.md
@@ -11,27 +11,20 @@ One of the more useful cases is flashing other (commercial) energy-monitoring sm
 The focus on the wiki is for plugs that are re-flashable "over the air" for simplicity, but if you're comfortable with soldering (and opening the plug) there are  an incredible number of compatible plugs/devices compatible with ESPHome.
 
 # Usage
-Place the `espsense.h` [custom component](https://esphome.io/custom/custom_component.html) in your ESPHome build directory, and then modify/create your ESPHome YAML definition to include:
-1. the `custom_component` details and lambda, to tell ESPSense which ESPHome sensor to utilize for power data (note: this can also be a [template sensor](https://esphome.io/components/sensor/template.html) that returns a wattage value!)
-2. an `includes:` directive, calling out the `espsense.h` file
-3. a `libraries:` directive, that specifies to include the libraries `ArduinoJson-esphome@5.13.3` and `ESPAsyncUDP` for ESP8266-based devices. **Note**: for ESP32-based devices do *not* include `ESPAsyncUDP`, the core library `AsyncUDP` is utilized instead.
+Modify/create your ESPHome YAML definition to include:
+1. an `external_component` directive, that specifies this component
+2. the `espsense` details, to tell ESPSense which ESPHome sensor(s) to utilize for power data (note: this can also be a [template sensor](https://esphome.io/components/sensor/template.html) that returns a wattage value!)
 
-rom the included example YAML file:
+From the included example YAML file:
 
 ```yaml
-esphome:
-  name: espsense
-  ...
-  # Include espsense.h custom component file
-  includes:
-    - espsense.h
-  # Uses the libraries:
-  # - ESPAsyncUDP, to handle UDP communication
-  # - ArduinoJson-esphomelib, which might already be included if using the ESPHome webserver
-  libraries:
-    - "ESPAsyncUDP"   # do not include if using an ESP32 board or device!
-    - "ArduinoJson-esphomelib@5.13.3"
-    
+external_components:
+  # Pull the esphome component in from this GitHub repo
+  # - source: github://cbpowell/ESPSense
+  - source:
+      type: local
+      path: components 
+    components: [ espsense ]
 
 # Template sensor as an example
 sensor:
@@ -40,37 +33,26 @@ sensor:
     id: test_sensor
     unit_of_measurement: W
   
-custom_component:
-  # Create ESPSense instance, passing the ID of the sensor it should retrieve
-  # power data from
-- lambda: |-
-    float voltage = 120.0;
-    auto sensor_power = new ESPSense(id(test_sensor), voltage);
-    return {sensor_power};
+espsense:
+  # You can define up to 10 "plugs" to report to Sense
+  # Power value can come from any of the following:
+  #   * A power sensor (in Watts)
+  #   * Calculated from a current sensor (in Amps) and a voltage sensor (in Volts)
+  #   * Calculated from a current sensor (in Amps) and a fixed voltage value
+  plugs:
+    - name: espsense
+      power_sensor: test_sensor
+      # current_sensor: some_current_sensor
+      # voltage_sensor: some_voltage_sensor
+      # voltage: 120.0
+      # encrypt: false
+      # mac_address: 35:4B:91:A1:FE:CC
 ```
 
 Note that whatever sensor you tell ESPSense to monitor is assumed to report a **state in the units of watts!** If you want to report the power usage of a device indirectly (such as scaled on another parameter, or simply if on or off), you'll need to create a template sensor in ESPHome to calculate/report the wattage.
 
-By default, the MAC address of your ESP device will be reported to Sense. You can configure that manually if desired. See the `espsense.h` file for the alternate constructor methods.
+By default, a MAC address generated from a hash of the plug name will be reported to Sense. You can configure that manually if desired.
 
-## Advanced Usage
-If you're using a device that measures power/voltage/current of more than one thing, ESPSense also supports reporting back multiple "plugs" to Sense. In the custom component lambda, you can configure each plug and add it to the ESPSense component. The plug `voltage_sid` and `current_sid` sensor ID values are optional, and ESPSense will fall back to using the specified static voltage and calculating current from power / voltage, respectively, if not specified.
-```yaml
-custom_component:
-  # Create ESPSense instance, passing the ID of the sensor it should retrieve
-  # power data from
-- lambda: |-
-    // Define "plugs"
-    ESPSensePlug plug1 = ESPSensePlug(id(power_sensor1), "50:c7:bf:f6:2b:01", "plug1", 120.0);
-    ESPSensePlug plug2 = ESPSensePlug(id(power_sensor2), "50:c7:bf:f6:2b:02", "plug2", 120.0);
-    // Plug1 also measures voltage
-    plug1.voltage_sid = voltage_sensor1; // ID of voltage sensor
-    // Add to ESPSense
-    auto sense = new ESPSense();
-    sense->addPlug(plug1);
-    sense->addPlug(plug2);
-    return {sense};
-```
 Sense does not currently care about plug voltage or current readings, but this is implemented to support data collection by things other than Sense, or in case Sense does eventually implement it!
 
 

--- a/components/espsense/__init__.py
+++ b/components/espsense/__init__.py
@@ -1,0 +1,79 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.core import CORE
+from esphome.components import sensor
+from esphome.const import CONF_ID, CONF_NAME, CONF_VOLTAGE, CONF_MAC_ADDRESS
+
+AUTO_LOAD = ["json"]
+
+CONF_PLUGS = "plugs"
+CONF_POWER_SENSOR = "power_sensor"
+CONF_CURRENT_SENSOR = "current_sensor"
+CONF_VOLTAGE_SENSOR = "voltage_sensor"
+CONF_ENCRYPT = "encrypt"
+
+json_ns = cg.esphome_ns.namespace("json")
+
+espsense_ns = cg.esphome_ns.namespace("espsense")
+ESPSense = espsense_ns.class_("ESPSense", cg.Component)
+ESPSensePlug = espsense_ns.class_("ESPSensePlug")
+
+def validate_plug_config(config):
+    if CONF_POWER_SENSOR in config:
+        return config
+    elif CONF_CURRENT_SENSOR in config and CONF_VOLTAGE_SENSOR in config:
+        return config
+    elif CONF_CURRENT_SENSOR in config and CONF_VOLTAGE in config:
+        return config
+
+    raise cv.Invalid('invalid plug config')
+    
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ESPSense),
+            cv.Required(CONF_PLUGS): cv.All(
+                cv.ensure_list(
+                    {
+                        cv.GenerateID(): cv.declare_id(ESPSensePlug),
+                        cv.Required(CONF_NAME): cv.string,
+                        cv.Optional(CONF_POWER_SENSOR): cv.use_id(sensor.Sensor),
+                        cv.Optional(CONF_CURRENT_SENSOR): cv.use_id(sensor.Sensor),
+                        cv.Optional(CONF_VOLTAGE_SENSOR): cv.use_id(sensor.Sensor),
+                        cv.Optional(CONF_VOLTAGE, default="120.0"): cv.positive_float,
+                        cv.Optional(CONF_ENCRYPT, default="true"): cv.boolean,
+                        cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
+                    },
+                    validate_plug_config,
+                ),
+                cv.Length(min=1)
+            )
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+async def to_code(config):
+    if CORE.is_esp8266:
+        cg.add_library("ESPAsyncUDP", "")
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    for plug_config in config[CONF_PLUGS]:
+        plug_var = cg.new_Pvariable(plug_config[CONF_ID])
+        cg.add(plug_var.set_name(plug_config[CONF_NAME]))
+        if CONF_POWER_SENSOR in plug_config:
+            power_sensor = await cg.get_variable(plug_config[CONF_POWER_SENSOR])
+            cg.add(plug_var.set_power_sensor(power_sensor))
+        if CONF_CURRENT_SENSOR in plug_config:
+            current_sensor = await cg.get_variable(plug_config[CONF_CURRENT_SENSOR])
+            cg.add(plug_var.set_current_sensor(current_sensor))
+        if CONF_VOLTAGE_SENSOR in plug_config:
+            voltage_sensor = await cg.get_variable(plug_config[CONF_VOLTAGE_SENSOR])
+            cg.add(plug_var.set_voltage_sensor(voltage_sensor))
+        if CONF_MAC_ADDRESS in plug_config:
+            cg.add(plug_var.set_mac_address(plug_config[CONF_MAC_ADDRESS]))
+        cg.add(plug_var.set_voltage(plug_config[CONF_VOLTAGE]))
+        cg.add(plug_var.set_encrypt(plug_config[CONF_ENCRYPT]))
+        cg.add(var.addPlug(plug_var))

--- a/components/espsense/espsense.h
+++ b/components/espsense/espsense.h
@@ -38,13 +38,6 @@ class ESPSensePlug {
 
   ESPSensePlug() {}
 
-  ESPSensePlug(sensor::Sensor *sid, std::string config_mac, std::string config_name, float config_voltage) {
-    power_sid = sid;
-    mac = config_mac;
-    name = config_name;
-    voltage = config_voltage;
-  }
-
   void set_name(std::string name) { 
     this->name = name;
 

--- a/components/espsense/espsense.h
+++ b/components/espsense/espsense.h
@@ -1,7 +1,10 @@
 // Copyright 2020, Charles Powell
 
-#include "esphome.h"
-#include "ArduinoJson.h"
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/json/json_util.h"
+#include "esphome/components/sensor/sensor.h"
 
 #ifdef ARDUINO_ARCH_ESP32
 #include "AsyncUDP.h"
@@ -10,34 +13,56 @@
 #include "ESPAsyncUDP.h"
 #endif
 
+namespace esphome {
+namespace espsense {
+
 #define RES_SIZE 400
 #define REQ_SIZE 70
 #define MAX_PLUG_COUNT 10  // Somewhat arbitrary as of now
 
 class ESPSensePlug {
-public:
+ public:
   std::string name;
   std::string mac;
   bool encrypt = true;
   float voltage = 120.0;
-  Sensor *power_sid = NULL;
-  Sensor *voltage_sid = NULL;
-  Sensor *current_sid = NULL;
+  sensor::Sensor *power_sid = NULL;
+  sensor::Sensor *voltage_sid = NULL;
+  sensor::Sensor *current_sid = NULL;
   
   std::string base_json = "{\"emeter\": {\"get_realtime\":{ "
                               "\"current\": %.02f, \"voltage\": %.02f, \"power\": %.02f, \"total\": 0, \"err_code\": 0}}, "
                            "\"system\": {\"get_sysinfo\": "
                               "{\"err_code\": 0, \"hw_ver\": 1.0, \"type\": \"IOT.SMARTPLUGSWITCH\", \"model\": \"HS110(US)\", "
                            "\"mac\": \"%s\", \"deviceId\": \"%s\", \"alias\": \"%s\", \"relay_state\": 1, \"updating\": 0 }}}";
-  
-  
-  ESPSensePlug(Sensor *sid, std::string config_mac, std::string config_name, float config_voltage) {
+
+  ESPSensePlug() {}
+
+  ESPSensePlug(sensor::Sensor *sid, std::string config_mac, std::string config_name, float config_voltage) {
     power_sid = sid;
     mac = config_mac;
     name = config_name;
     voltage = config_voltage;
   }
+
+  void set_name(std::string name) { 
+    this->name = name;
+
+    // Generate a fake MAC address from the name to prevent issues when there are multiple "plugs" with the same MAC address
+    uint32_t name_hash = fnv1_hash(name);
+    uint8_t *hash_pointer = (uint8_t *)&name_hash;
+    char mac[20];
+    sprintf(mac, "%02X:%02X:%02X:%02X:%02X:%02X", 53, 75, hash_pointer[0], hash_pointer[1], hash_pointer[3], hash_pointer[4]);
+    this->set_mac_address(mac);
+  }
   
+  void set_mac_address(std::string mac) { this->mac = mac; }
+  void set_encrypt(bool encrypt) { this->encrypt = encrypt; }
+  void set_voltage(float voltage) { this->voltage = voltage; }
+  void set_power_sensor(sensor::Sensor *sensor) { this->power_sid = sensor; }
+  void set_voltage_sensor(sensor::Sensor *sensor) { this->voltage_sid = sensor; }
+  void set_current_sensor(sensor::Sensor *sensor) { this->current_sid = sensor; }
+
   float get_power() {
     return get_sensor_reading(power_sid, 0.0);
   }
@@ -50,7 +75,7 @@ public:
     return get_sensor_reading(current_sid, get_power() / get_voltage());
   }
   
-  float get_sensor_reading(Sensor *sid, float default_value) {
+  float get_sensor_reading(sensor::Sensor *sid, float default_value) {
     if(sid != NULL && id(sid).has_state()) {
       return id(sid).state;
     } else {
@@ -71,24 +96,8 @@ public:
 class ESPSense : public Component {
 public:
   AsyncUDP udp;
-  Sensor* sensor_id = NULL;
   
   ESPSense() : Component() {}
-  
-  ESPSense(Sensor *sid, float conf_voltage = 120.0) : Component() {
-    // Generate single plug
-    std::string name = App.get_name();
-    std::string mac = get_mac_address_pretty();
-    
-    ESPSensePlug plug = ESPSensePlug(sid, mac, name, conf_voltage);
-    addPlug(plug);
-  }
-  
-  ESPSense(Sensor *sid, std::string mac, std::string alias, float voltage = 120.0) : Component() {
-    // Generate single plug
-    ESPSensePlug plug = ESPSensePlug(sid, mac, alias, voltage);
-    addPlug(plug);
-  }
   
   float get_setup_priority() const override { return esphome::setup_priority::AFTER_WIFI; }
   
@@ -101,8 +110,8 @@ public:
       ESP_LOGE("ESPSense", "Failed to start UDP listener!");
     }
   }
-  
-  void addPlug(ESPSensePlug plug) {
+
+  void addPlug(ESPSensePlug *plug) {
     if(plug_count > (MAX_PLUG_COUNT - 1)) {
       ESP_LOGW("ESPSense", "Attempted to add more than %ui plugs, ignoring", plug_count);
     }
@@ -113,7 +122,7 @@ public:
 private:
   float voltage;
   char response_buf[RES_SIZE];
-  std::vector<ESPSensePlug> plugs;
+  std::vector<ESPSensePlug *> plugs;
   uint plug_count = 0;
   
   StaticJsonBuffer<200> jsonBuffer;
@@ -156,7 +165,7 @@ private:
     JsonVariant request = req["emeter"]["get_realtime"];
     if (request.success()) {
       ESP_LOGD("ESPSense", "Power measurement requested");
-      for (auto plug = begin(plugs); plug != end(plugs); ++plug) {
+      for (auto *plug : this->plugs) {
         // Generate JSON response string
         int response_len = plug->generate_response(response_buf);
         char response[response_len];
@@ -195,3 +204,6 @@ private:
     }
   }
 };
+
+}  // namespace espsense
+}  // namespace esphome

--- a/configs/espsense-BN-Link_BNC-60_U133TJ.yml
+++ b/configs/espsense-BN-Link_BNC-60_U133TJ.yml
@@ -18,12 +18,6 @@ esphome:
   name: ${plug_name}
   platform: ESP8266
   board: esp01_1m
-  includes:
-    - espsense.h
-  # Uses the ESPAsyncUDP library
-  libraries:
-    - "ESPAsyncUDP"
-    - "ArduinoJson-esphomelib@5.13.3"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -152,8 +146,13 @@ sensor:
   - platform: uptime
     name: ${plug_name} Uptime Sensor
     
-custom_component:
-- lambda: |-
-    auto sensor_power = new ESPSense(id(wattage), 120);
-    return {sensor_power};
+external_components:
+  - source: github://cbpowell/ESPSense
+    components: [ espsense ]
+
+espsense:
+  plugs:
+    - name: ${plug_name}
+      power_sensor: wattage
+      voltage: 120.0
     

--- a/configs/espsense-EFUN_SH331W.yml
+++ b/configs/espsense-EFUN_SH331W.yml
@@ -18,12 +18,6 @@ esphome:
   name: ${plug_name}
   platform: ESP8266
   board: esp01_1m
-  includes:
-    - espsense.h
-  # Uses the ESPAsyncUDP library
-  libraries:
-    - "ESPAsyncUDP"
-    - "ArduinoJson-esphomelib@5.13.3"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -149,7 +143,12 @@ sensor:
   - platform: uptime
     name: ${plug_name} Uptime Sensor
     
-custom_component:
-- lambda: |-
-    auto sensor_power = new ESPSense(id(wattage), 120);
-    return {sensor_power};
+external_components:
+  - source: github://cbpowell/ESPSense
+    components: [ espsense ]
+
+espsense:
+  plugs:
+    - name: ${plug_name}
+      power_sensor: wattage
+      voltage: 120.0

--- a/configs/espsense-TopGreener_TGWF115APM.yml
+++ b/configs/espsense-TopGreener_TGWF115APM.yml
@@ -18,12 +18,6 @@ esphome:
   name: ${plug_name}
   platform: ESP8266
   board: esp01_1m
-  includes:
-    - espsense.h
-  # Uses the ESPAsyncUDP library
-  libraries:
-    - "ESPAsyncUDP"
-    - "ArduinoJson-esphomelib@5.13.3"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -141,8 +135,13 @@ sensor:
   - platform: uptime
     name: ${plug_name} Uptime Sensor
     
-custom_component:
-- lambda: |-
-    auto sensor_power = new ESPSense(id(wattage), 120);
-    return {sensor_power};
+external_components:
+  - source: github://cbpowell/ESPSense
+    components: [ espsense ]
+
+espsense:
+  plugs:
+    - name: ${plug_name}
+      power_sensor: wattage
+      voltage: 120.0
     

--- a/configs/espsense-TopGreener_TGWF115PQM.yml
+++ b/configs/espsense-TopGreener_TGWF115PQM.yml
@@ -18,12 +18,6 @@ esphome:
   name: ${plug_name}
   platform: ESP8266
   board: esp01_1m
-  includes:
-    - espsense.h
-  # Uses the ESPAsyncUDP library
-  libraries:
-    - "ESPAsyncUDP"
-    - "ArduinoJson-esphomelib@5.13.3"
 
 wifi:
   ssid: !secret wifi_ssid
@@ -144,7 +138,13 @@ sensor:
   - platform: uptime
     name: ${plug_name} Uptime Sensor
     
-custom_component:
-- lambda: |-
-    auto sensor_power = new ESPSense(id(wattage), 120);
-    return{sensor_power};
+external_components:
+  - source: github://cbpowell/ESPSense
+    components: [ espsense ]
+
+espsense:
+  plugs:
+    - name: ${plug_name}
+      power_sensor: wattage
+      voltage: 120.0
+    

--- a/espsense-example.yml
+++ b/espsense-example.yml
@@ -2,13 +2,6 @@ esphome:
   name: espsense
   platform: ESP8266
   board: nodemcu
-  # Include espsense.h custom component file
-  includes:
-    - espsense.h
-  # Uses the ESPAsyncUDP library
-  libraries:
-    - "ESPAsyncUDP"
-    - "ArduinoJson-esphomelib@5.13.3"
     
 
 wifi:
@@ -51,11 +44,25 @@ time:
               - lambda: !lambda |-
                   long randomPowerState = random(5, 15);
                   id(test_sensor).publish_state((float)randomPowerState);
-  
-custom_component:
-  # Create a new ESPSense component with the ID of ESPHome power sensor
-  # Sensor can be a template that calculates (or reports) power from a *different*
-  # sensor or switch as well!
-- lambda: |-
-    auto sensor_power = new ESPSense(id(test_sensor), 120);
-    return {sensor_power};
+
+
+external_components:
+  # Pull the esphome component in from this GitHub repo
+  # - source: github://cbpowell/ESPSense
+  - source:
+      type: local
+      path: components 
+    components: [ espsense ]
+
+espsense:
+  # You can define up to 10 "plugs" to report to Sense
+  # Power value can come from any of the following:
+  #   * A power sensor (in Watts)
+  #   * Calculated from a current sensor (in Amps) and a voltage sensor (in Volts)
+  #   * Calculated from a current sensor (in Amps) and a fixed voltage value
+  plugs:
+    - name: espsense
+      power_sensor: test_sensor
+      # current_sensor: some_current_sensor
+      # voltage_sensor: some_voltage_sensor
+      # voltage: 120.0

--- a/espsense-example.yml
+++ b/espsense-example.yml
@@ -48,10 +48,7 @@ time:
 
 external_components:
   # Pull the esphome component in from this GitHub repo
-  # - source: github://cbpowell/ESPSense
-  - source:
-      type: local
-      path: components 
+  - source: github://cbpowell/ESPSense
     components: [ espsense ]
 
 espsense:
@@ -66,3 +63,5 @@ espsense:
       # current_sensor: some_current_sensor
       # voltage_sensor: some_voltage_sensor
       # voltage: 120.0
+      # encrypt: false
+      # mac_address: 35:4B:91:A1:FE:CC


### PR DESCRIPTION
This PR converts the ESPSense component to an "external component" making it easier to add to ESPHome configs and resolves issue #6.