### PR TITLE
Fix MAC address generation

### DIFF
--- a/components/espsense/espsense.h
+++ b/components/espsense/espsense.h
@@ -111,7 +111,7 @@ public:
         uint32_t name_hash = fnv1_hash(plug->name);
         uint8_t *hash_pointer = (uint8_t *)&name_hash;
         char mac[20];
-        sprintf(mac, "%02X:%02X:%02X:%02X:%02X:%02X", 53, 75, hash_pointer[0], hash_pointer[1], hash_pointer[3], hash_pointer[4]);
+        sprintf(mac, "%02X:%02X:%02X:%02X:%02X:%02X", 53, 75, hash_pointer[0], hash_pointer[1], hash_pointer[2], hash_pointer[3]);
         plug->set_mac_address(mac);
       }
     }


### PR DESCRIPTION
@cbpowell Small PR to fix a bug I discovered. My Sense device now has about 20 versions of my pool cleaner because every time I updated something the last octet of the MAC address would change to some new random number.