### PR TITLE
feat: add ESP-IDF framework support by migrating to ESPHome socket API

### DIFF
--- a/components/espsense/__init__.py
+++ b/components/espsense/__init__.py
@@ -54,11 +54,6 @@ CONFIG_SCHEMA = (
 )
 
 async def to_code(config):
-    if CORE.is_esp8266:
-        cg.add_library("ESPAsyncUDP", "")
-    elif CORE.is_esp32:
-        cg.add_library("ESP32 Async UDP", None)
-
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 


### PR DESCRIPTION
Replace Arduino-specific AsyncUDP library with ESPHome's cross-platform socket API to enable compatibility with both Arduino and ESP-IDF frameworks.

Changes:
- Replace AsyncUDP/ESPAsyncUDP with socket::socket_ip() for UDP communication
- Convert from callback-based packet handling (onPacket) to polling in loop()
- Add framework-specific IP address formatting for lwIP (Arduino) and BSD sockets (ESP-IDF)
- Remove ESPAsyncUDP and ESP32 Async UDP library dependencies
- Add loop() override to poll for incoming UDP packets
- Maintain backward compatibility with existing ESPSense functionality

This allows the component to work with ESP-IDF framework while maintaining full support for Arduino framework on ESP8266 and ESP32.

Fixes compilation errors when using framework: { type: esp-idf } in ESPHome.